### PR TITLE
add ServletContextListener handling

### DIFF
--- a/src/tailrecursion/ClojureAdapterServletContextListener.java
+++ b/src/tailrecursion/ClojureAdapterServletContextListener.java
@@ -1,0 +1,34 @@
+/***************************************************************************************************
+*** Copyright 2014 jumblerg.
+*** All rights reserved. The use and distribution terms terms for this software are covered by the
+*** Eclipse Public License 1.0 (http://www.eclipse.org/legal/epl-v10.html). By using this software
+*** in any fashion, you are agreeing to be bound by the terms of this license.  You must not remove
+*** this notice, or any other, from this software.
+***************************************************************************************************/
+
+package tailrecursion;
+
+import clojure.lang.RT;
+import clojure.lang.Symbol;
+import clojure.lang.Var;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+public class ClojureAdapterServletContextListener implements ServletContextListener {
+
+  private static final Var REQUIRE = RT.var("clojure.core", "require");
+
+  static { REQUIRE.invoke(Symbol.intern("tailrecursion.clojure-adapter-servlet.impl")); }
+
+  private static final Var INITIALIZED = RT.var("tailrecursion.clojure-adapter-servlet.impl", "context-initialized");
+  private static final Var DESTROYED   = RT.var("tailrecursion.clojure-adapter-servlet.impl", "context-destroyed");
+
+  public void contextInitialized(ServletContextEvent sce) {
+    INITIALIZED.invoke(sce);
+  }
+
+  public void contextDestroyed(ServletContextEvent sce) {
+    DESTROYED.invoke(sce);
+  }
+}


### PR DESCRIPTION
- run a function when servlet is loaded, unloaded by container
- vs. servlet init/destroy which are per handler thread

I'm using this to run Kinesis Consumers on Beanstalk as Java apps.  The Kinesis consumption begins when the servlet is first loaded, similar to this example code: https://github.com/awslabs/aws-big-data-blog/blob/master/aws-blog-kinesis-beanstalk-workers/src/main/java/com/amazon/kinesis/beanstalk/connector/KinesisWorkerServletInitiator.java, except we resolve Clojure vars instead of using Java reflection.

Thanks for giving it a look @jumblerg!
